### PR TITLE
ci: migrate workflows to Node.js 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -147,7 +147,7 @@ jobs:
       - name: Upsert PR comment
         if: always() && github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           STATUS: ${{ steps.classify.outputs.status }}
           WARN_COUNT: ${{ steps.classify.outputs.warn_count }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,11 @@ jobs:
     name: Build sdist and wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0  # full history + tags, required for setuptools_scm
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -32,7 +32,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -45,7 +45,7 @@ jobs:
     permissions:
       id-token: write  # required for OIDC trusted publishing, no API token needed
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/
@@ -62,11 +62,11 @@ jobs:
     permissions:
       contents: write  # required to create releases
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
  
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
  
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
  
@@ -27,4 +27,3 @@ jobs:
  
       - name: Run tests
         run: pytest ndspec/tests
-


### PR DESCRIPTION
## Summary

- update checkout, setup-python, artifact, and github-script action versions to Node.js 24-compatible releases
- leave the composite/Docker PyPI publish action unchanged

Closes #114

## Verification

- `python -m pytest ndspec/tests -q` — 128 passed, 5 skipped, 12 warnings
- YAML parse and static action-reference check passed
- `git diff --check` passed